### PR TITLE
MR Allow not to use dedicated certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Key | Description | Default
 `mariadb.auth.username` | Database user to create | `""`
 `mariadb.auth.password` | Password for the user | `""`
 `ingress.enabled` | Enable use of ingress controllers | `true`
-`ingress.tls` | Create certificates if not exists | `true`
+`ingress.tls` | Use dedicated certificates | `true`
 `ingress.hosts` | OCS hosts to create application URLs | `""`
 `ingress.annotations` | An array of ingress annotations | `{}`
 `ingress.basicauth.enabled`  | Wether to enable basic auth | `"false"`

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Key | Description | Default
 `mariadb.auth.username` | Database user to create | `""`
 `mariadb.auth.password` | Password for the user | `""`
 `ingress.enabled` | Enable use of ingress controllers | `true`
+`ingress.tls` | Create certificates if not exists | `true`
 `ingress.hosts` | OCS hosts to create application URLs | `""`
 `ingress.annotations` | An array of ingress annotations | `{}`
 `ingress.basicauth.enabled`  | Wether to enable basic auth | `"false"`

--- a/charts/ocsinventory/templates/ingress.yaml
+++ b/charts/ocsinventory/templates/ingress.yaml
@@ -14,7 +14,9 @@ spec:
     - hosts:
       {{- range .Values.ingress.hosts }}
         - {{ . }}
-      secretName: {{ . }}-tls
+          {{- if $.Values.ingress.tls }}
+      secretName: {{ . }}-tls      
+          {{- end}}
       {{- end}}
   rules:
     {{- range .Values.ingress.hosts }}

--- a/charts/ocsinventory/values.yaml
+++ b/charts/ocsinventory/values.yaml
@@ -81,6 +81,7 @@ ingress:
   labels: {}
   hosts:
     - ""
+  tls: true
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"


### PR DESCRIPTION
Allow to use default ingress controller wild card certificates instead of dedicated ones. Then usage of wild card certificates provided by the ingress controller will be supported. Else user may access the wild card  certificate key and cert to create secrets with the correct name inside the ocs namespace.

This proposal is fully compatible with previous helm installations using the previous behaviour as default and allow to switch between the two ways of work (dedicated or centralized certificates). 

