### PR TITLE
MR Fix job cleanning issue

### DIFF
--- a/charts/ocsinventory/templates/job-dbcreate.yaml
+++ b/charts/ocsinventory/templates/job-dbcreate.yaml
@@ -9,6 +9,7 @@ metadata:
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   activeDeadlineSeconds: 300
+  ttlSecondsAfterFinished: 60
   backoffLimit: 10
   completions: 1
   parallelism: 1


### PR DESCRIPTION
In some case (I've not identify the reason), the job created by helm are not cleanned after terminating. The full use case is describe bellow. This behavior can be fixed just adding one line in file _job-dbcreate.yaml_ :

`ttlSecondsAfterFinished: 60`

Then 60s after termination the jobb, it will be deleted.

The full use case (not working all times):

First install the helm:

```
helm upgrade --install ocs ocsinventory/ocsinventory -n ocs -f ./values.yaml --create-namespace
```

Pods are created:
```
kubectl get pods -n ocs
NAME                                READY   STATUS    RESTARTS   AGE
ocs-jobdb-mx6gq                     1/1     Running   0          2m17s
ocs-mariadb-0                       1/1     Running   0          2m17s
ocs-ocsinventory-6856ffbb9b-h7f82   1/1     Running   0          2m17s
```
And job too:
```
kubectl get jobs -n ocs
NAME        COMPLETIONS   DURATION   AGE
ocs-jobdb   0/1           80s        80s
```

Lets wait few time to let job to be completed

```
kubectl get pods -n ocs
NAME                                READY   STATUS      RESTARTS   AGE
ocs-jobdb-mx6gq                     0/1     Completed   0          4m1s
ocs-mariadb-0                       1/1     Running     0          4m1s
ocs-ocsinventory-6856ffbb9b-h7f82   1/1     Running     0          4m1s

kubectl get jobs -n ocs
NAME        COMPLETIONS   DURATION   AGE
ocs-jobdb   1/1           3m57s      4m27s
```

The pod's job is not present any more but sometime the job is still here.

Now uninstall the helm

```
helm uninstall -n ocs ocs
release "ocs" uninstalled
```

There is no pods any more and this is good

```
kubectl get pods -n ocs
NAME                                READY   STATUS    RESTARTS   AGE
```
but the completed job is still here

```
kubectl get jobs -n ocs
NAME        COMPLETIONS   DURATION   AGE
ocs-jobdb   1/1           3m57s      5m11s
```

Then when trying to réinstall helm, it crashs because the job already exists.

```
helm upgrade --install ocs ocsinventory/ocsinventory -n ocs -f ./values.yaml --create-namespace
Release "ocs" does not exist. Installing it now.
Error: failed post-install: warning: Hook post-install ocsinventory/templates/job-dbcreate.yaml failed: 1 error occurred:
        * jobs.batch "ocs-jobdb" already exists
```
