### PR TITLE
MR add option to expose apache2 metrics inside cluster  and register it into an existing prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,16 @@ Key | Description | Default
 `ingress.basicauth.authRealm` | Basic auth directive | `Authentication Required`
 `ingress.basicauth.paths` | Paths with basic auth | `/ocsapi` `/ocsinventory`
 `resources` | CPU/Memory resource requests/limits for OCS pod | `{}`
+`metrics.enabled` | Enable metrics| `false`
+`metrics.image.repository` | apache-exporter Image | `docker.io/bitnami/apache-exporter`
+`metrics.image.tag` | Metrics image version | `1.0.3-debian-11-r2`
+`metrics.image.pullPolicy` | Metrics image pull policy | `IfNotPresent`
+`metrics.serviceMonitor.enabled` | Create ServiceMonitor object | `false`
+`metrics.serviceMonitor.label.prometheus` | Prometheus label used for scrapping | `prometheus`
+`metrics.serviceMonitor.label.release` | Release label used for scrapping (should be the prometheus instance name)| `tobedefined`
+`metrics.resources` | CPU/Memory resource requests/limits for apache metrics pod | `{}`
+
+
 
 ## Acknowledgements
 

--- a/charts/ocsinventory/templates/deployment.yaml
+++ b/charts/ocsinventory/templates/deployment.yaml
@@ -73,6 +73,15 @@ spec:
             - mountPath: /etc/php/8.1/apache2/conf.d/ocsinventory.ini
               name: {{ template "ocsinventory.fullname" . }}-config
               subPath: phpconfig
+        {{- if .Values.metrics.enabled }}
+        - name: {{ .Chart.Name }}-apache-metrics
+          image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
+          imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
+          ports:
+            - name: metrics
+              containerPort: 9117
+              protocol: TCP
+        {{- end }}
       volumes:
         - name: {{ template "ocsinventory.fullname" . }}-data
           persistentVolumeClaim:

--- a/charts/ocsinventory/templates/deployment.yaml
+++ b/charts/ocsinventory/templates/deployment.yaml
@@ -81,6 +81,9 @@ spec:
             - name: metrics
               containerPort: 9117
               protocol: TCP
+          resources:
+            {{- toYaml .Values.metrics.resources | nindent 12 }}
+
         {{- end }}
       volumes:
         - name: {{ template "ocsinventory.fullname" . }}-data

--- a/charts/ocsinventory/templates/service.yaml
+++ b/charts/ocsinventory/templates/service.yaml
@@ -12,3 +12,21 @@ spec:
       name: http
   selector:
     {{- include "ocsinventory.selectorLabels" . | nindent 4 }}
+
+{{- if .Values.metrics.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "ocsinventory.fullname" . }}-apache-metrics
+  labels:
+    {{- include "ocsinventory.labels" . | nindent 4 }}
+spec:
+  ports:
+    - port: 9117
+      targetPort: 9117
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- include "ocsinventory.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/ocsinventory/templates/serviceMonitor.yaml
+++ b/charts/ocsinventory/templates/serviceMonitor.yaml
@@ -1,0 +1,23 @@
+
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "ocsinventory.fullname" . }}-apache-service-monitor
+  labels:
+    prometheus: {{ .Values.metrics.serviceMonitor.labels.prometheus }}
+    release: {{ .Values.metrics.serviceMonitor.labels.release }}
+    {{- include "ocsinventory.labels" . | nindent 4 }}    
+spec:
+  endpoints:
+  - port: metrics
+    targetPort: 9117
+    path: /metrics
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "ocsinventory.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/ocsinventory/values.yaml
+++ b/charts/ocsinventory/values.yaml
@@ -112,7 +112,7 @@ resources:
     memory: 256Mi
 
 metrics:
-    enabled: true
+    enabled: false
     image: 
       repository: "docker.io/bitnami/apache-exporter"
       tag: "1.0.3-debian-11-r2"

--- a/charts/ocsinventory/values.yaml
+++ b/charts/ocsinventory/values.yaml
@@ -110,3 +110,20 @@ resources:
   requests:
     cpu: 100m
     memory: 256Mi
+
+metrics:
+    enabled: true
+    image: 
+      repository: "docker.io/bitnami/apache-exporter"
+      tag: "1.0.3-debian-11-r2"
+      pullPolicy: IfNotPresent
+    service:
+      port: 9117
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "{{ .Values.metrics.service.port }}"
+    serviceMonitor:
+      enabled: false
+      labels:
+         prometheus: prometheus
+         release: tobedefined

--- a/charts/ocsinventory/values.yaml
+++ b/charts/ocsinventory/values.yaml
@@ -117,13 +117,15 @@ metrics:
       repository: "docker.io/bitnami/apache-exporter"
       tag: "1.0.3-debian-11-r2"
       pullPolicy: IfNotPresent
-    service:
-      port: 9117
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "{{ .Values.metrics.service.port }}"
     serviceMonitor:
       enabled: false
       labels:
          prometheus: prometheus
          release: tobedefined
+    resources:
+      limits:
+        cpu: 200m
+        memory: 256Mi
+      requests:
+        cpu: 100m
+        memory: 100Mi


### PR DESCRIPTION
Provide a sidecar prometheus exporter for apache to be activated using the values file and provide all mechanisms to register metrics inside an existing prometheus instance.

Prerequisites: install a prometheus with ServiceMonitor activated.

My test environment is installed  with:

```
helm repo add prom https://prometheus-community.github.io/helm-charts
helm repo update
helm upgrade --install my-prometheus  prom/kube-prometheus-stack   -n my-supervision --create-namespace -f ./prom-values.yaml
```

The  prom-values is attached (rename it into prom-values.yaml)

[prom-values.yaml.txt](https://github.com/OCSInventory-NG/helm-charts/files/13729320/prom-values.yaml.txt)

