### PR TITLE
Add ingress class name k8s v1.18+

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,51 +93,52 @@ Lastly, set up the username and password for basic authentication.
 
 ## Values
 
-Key | Description | Default
---: | :--: | :--
-`image.repository` | ocsinventory Image | `ocsinventory/ocsinventory-docker-image`
-`image.pullPolicy` | Image pull policy | `IfNotPresent`
-`image.tag` | Image version | `2.12.1`
-`replicaCount` | Number of ocs pod to deployed | `1`
-`phpconfig.ocsinventory.ini` | Additional php.ini configuration | `config`
-`persistense.enabled` | Enable persistence using PVC | `true`
-`persistense.size` | PVC Storage Request for OCS volume | `10Gi`
-`persistense.accessMode` | PVC Access Mode for OCS volume | `ReadWriteOnce`
-`persistense.storageClass` | PVC Storage Class for OCS volume | `""`
-`persistense.existingClaim` | An Existing PVC name for OCS volume | `""`
-`externalDatabase.enalbed` | Whether to use external database | `false`
-`externalDatabase.hostname` | Host of the external database | `""`
-`externalDatabase.username` | Username of the external database | `""`
-`externalDatabase.password` | Password for the user of the external database | `""`
-`externalDatabase.database` | Name of the external databse | `""`
-`database.create` | Wether to create a OCS database | `false`
-`database.db_name` | Database name to create | `""`
-`database.db_user` | Database user to create | `""`
-`database.db_pass` | Password for the database | `""`
-`database.db_server` | Name of the database service | `""`
-`mariadb.enabled` | Whether to create a MariaDB server | `true`
-`mariadb.auth.rootPasswd` | MariaDB admin password | `""`
-`mariadb.auth.database` | Database name to create | `""`
-`mariadb.auth.username` | Database user to create | `""`
-`mariadb.auth.password` | Password for the user | `""`
-`ingress.enabled` | Enable use of ingress controllers | `true`
-`ingress.tls` | Use dedicated certificates | `true`
-`ingress.hosts` | OCS hosts to create application URLs | `""`
-`ingress.annotations` | An array of ingress annotations | `{}`
-`ingress.basicauth.enabled`  | Wether to enable basic auth | `"false"`
-`ingress.basicauth.username`  | Username for basic auth | `""`
-`ingress.basicauth.password`  | Password for basic auth | `""`
-`ingress.basicauth.authRealm` | Basic auth directive | `Authentication Required`
-`ingress.basicauth.paths` | Paths with basic auth | `/ocsapi` `/ocsinventory`
-`resources` | CPU/Memory resource requests/limits for OCS pod | `{}`
-`metrics.enabled` | Enable metrics| `false`
-`metrics.image.repository` | apache-exporter Image | `docker.io/bitnami/apache-exporter`
-`metrics.image.tag` | Metrics image version | `1.0.3-debian-11-r2`
-`metrics.image.pullPolicy` | Metrics image pull policy | `IfNotPresent`
-`metrics.serviceMonitor.enabled` | Create ServiceMonitor object | `false`
-`metrics.serviceMonitor.label.prometheus` | Prometheus label used for scrapping | `prometheus`
-`metrics.serviceMonitor.label.release` | Release label used for scrapping (should be the prometheus instance name)| `tobedefined`
-`metrics.resources` | CPU/Memory resource requests/limits for apache metrics pod | `{}`
+Key |                               Description                                | Default
+--: |:------------------------------------------------------------------------:| :--
+`image.repository` |                            ocsinventory Image                            | `ocsinventory/ocsinventory-docker-image`
+`image.pullPolicy` |                            Image pull policy                             | `IfNotPresent`
+`image.tag` |                              Image version                               | `2.12.1`
+`replicaCount` |                      Number of ocs pod to deployed                       | `1`
+`phpconfig.ocsinventory.ini` |                     Additional php.ini configuration                     | `config`
+`persistense.enabled` |                       Enable persistence using PVC                       | `true`
+`persistense.size` |                    PVC Storage Request for OCS volume                    | `10Gi`
+`persistense.accessMode` |                      PVC Access Mode for OCS volume                      | `ReadWriteOnce`
+`persistense.storageClass` |                     PVC Storage Class for OCS volume                     | `""`
+`persistense.existingClaim` |                   An Existing PVC name for OCS volume                    | `""`
+`externalDatabase.enalbed` |                     Whether to use external database                     | `false`
+`externalDatabase.hostname` |                      Host of the external database                       | `""`
+`externalDatabase.username` |                    Username of the external database                     | `""`
+`externalDatabase.password` |              Password for the user of the external database              | `""`
+`externalDatabase.database` |                       Name of the external databse                       | `""`
+`database.create` |                     Wether to create a OCS database                      | `false`
+`database.db_name` |                         Database name to create                          | `""`
+`database.db_user` |                         Database user to create                          | `""`
+`database.db_pass` |                        Password for the database                         | `""`
+`database.db_server` |                       Name of the database service                       | `""`
+`mariadb.enabled` |                    Whether to create a MariaDB server                    | `true`
+`mariadb.auth.rootPasswd` |                          MariaDB admin password                          | `""`
+`mariadb.auth.database` |                         Database name to create                          | `""`
+`mariadb.auth.username` |                         Database user to create                          | `""`
+`mariadb.auth.password` |                          Password for the user                           | `""`
+`ingress.enabled` |                    Enable use of ingress controllers                     | `true`
+`ingress.tls` |                        Use dedicated certificates                        | `true`
+`ingress.ingressClassName` |                    Ingress Class Name for k8s >= v1.18                   | `"nginx"`
+`ingress.hosts` |                   OCS hosts to create application URLs                   | `""`
+`ingress.annotations` |                     An array of ingress annotations                      | `{}`
+`ingress.basicauth.enabled`  |                       Wether to enable basic auth                        | `"false"`
+`ingress.basicauth.username`  |                         Username for basic auth                          | `""`
+`ingress.basicauth.password`  |                         Password for basic auth                          | `""`
+`ingress.basicauth.authRealm` |                           Basic auth directive                           | `Authentication Required`
+`ingress.basicauth.paths` |                          Paths with basic auth                           | `/ocsapi` `/ocsinventory`
+`resources` |             CPU/Memory resource requests/limits for OCS pod              | `{}`
+`metrics.enabled` |                              Enable metrics                              | `false`
+`metrics.image.repository` |                          apache-exporter Image                           | `docker.io/bitnami/apache-exporter`
+`metrics.image.tag` |                          Metrics image version                           | `1.0.3-debian-11-r2`
+`metrics.image.pullPolicy` |                        Metrics image pull policy                         | `IfNotPresent`
+`metrics.serviceMonitor.enabled` |                       Create ServiceMonitor object                       | `false`
+`metrics.serviceMonitor.label.prometheus` |                   Prometheus label used for scrapping                    | `prometheus`
+`metrics.serviceMonitor.label.release` |Release label used for scrapping (should be the prometheus instance name) | `tobedefined`
+`metrics.resources` |        CPU/Memory resource requests/limits for apache metrics pod        | `{}`
 
 
 

--- a/README.md
+++ b/README.md
@@ -86,59 +86,63 @@ Based on the chosen option, configure the associated parameters such as
 username, password, hostname, database name, and root password. Additional
 parameters to configure include persistence.storageClass, ingress.hosts. 
 
-Within the ingress annotations, configure the cluster-issuer and ingress.class. If you
-want to authorize only specific IPs or ranges, adjust the whitelist-source-range. 
+Within the ingress annotations, configure the cluster-issuer. If you
+want to authorize only specific IPs or ranges, adjust the whitelist-source-range.
+
+Ingress class configuration, for k8s: 
+  * before v1.18 => configure the ingress class name in the ingress.annotation
+  * v1.18+ => configure the "ingress.ingressClassName"
 
 Lastly, set up the username and password for basic authentication.
 
 ## Values
 
-Key |                               Description                                | Default
---: |:------------------------------------------------------------------------:| :--
-`image.repository` |                            ocsinventory Image                            | `ocsinventory/ocsinventory-docker-image`
-`image.pullPolicy` |                            Image pull policy                             | `IfNotPresent`
-`image.tag` |                              Image version                               | `2.12.1`
-`replicaCount` |                      Number of ocs pod to deployed                       | `1`
-`phpconfig.ocsinventory.ini` |                     Additional php.ini configuration                     | `config`
-`persistense.enabled` |                       Enable persistence using PVC                       | `true`
-`persistense.size` |                    PVC Storage Request for OCS volume                    | `10Gi`
-`persistense.accessMode` |                      PVC Access Mode for OCS volume                      | `ReadWriteOnce`
-`persistense.storageClass` |                     PVC Storage Class for OCS volume                     | `""`
-`persistense.existingClaim` |                   An Existing PVC name for OCS volume                    | `""`
-`externalDatabase.enalbed` |                     Whether to use external database                     | `false`
-`externalDatabase.hostname` |                      Host of the external database                       | `""`
-`externalDatabase.username` |                    Username of the external database                     | `""`
-`externalDatabase.password` |              Password for the user of the external database              | `""`
-`externalDatabase.database` |                       Name of the external databse                       | `""`
-`database.create` |                     Wether to create a OCS database                      | `false`
-`database.db_name` |                         Database name to create                          | `""`
-`database.db_user` |                         Database user to create                          | `""`
-`database.db_pass` |                        Password for the database                         | `""`
-`database.db_server` |                       Name of the database service                       | `""`
-`mariadb.enabled` |                    Whether to create a MariaDB server                    | `true`
-`mariadb.auth.rootPasswd` |                          MariaDB admin password                          | `""`
-`mariadb.auth.database` |                         Database name to create                          | `""`
-`mariadb.auth.username` |                         Database user to create                          | `""`
-`mariadb.auth.password` |                          Password for the user                           | `""`
-`ingress.enabled` |                    Enable use of ingress controllers                     | `true`
-`ingress.tls` |                        Use dedicated certificates                        | `true`
-`ingress.ingressClassName` |                    Ingress Class Name for k8s >= v1.18                   | `"nginx"`
-`ingress.hosts` |                   OCS hosts to create application URLs                   | `""`
-`ingress.annotations` |                     An array of ingress annotations                      | `{}`
-`ingress.basicauth.enabled`  |                       Wether to enable basic auth                        | `"false"`
-`ingress.basicauth.username`  |                         Username for basic auth                          | `""`
-`ingress.basicauth.password`  |                         Password for basic auth                          | `""`
-`ingress.basicauth.authRealm` |                           Basic auth directive                           | `Authentication Required`
-`ingress.basicauth.paths` |                          Paths with basic auth                           | `/ocsapi` `/ocsinventory`
-`resources` |             CPU/Memory resource requests/limits for OCS pod              | `{}`
-`metrics.enabled` |                              Enable metrics                              | `false`
-`metrics.image.repository` |                          apache-exporter Image                           | `docker.io/bitnami/apache-exporter`
-`metrics.image.tag` |                          Metrics image version                           | `1.0.3-debian-11-r2`
-`metrics.image.pullPolicy` |                        Metrics image pull policy                         | `IfNotPresent`
-`metrics.serviceMonitor.enabled` |                       Create ServiceMonitor object                       | `false`
-`metrics.serviceMonitor.label.prometheus` |                   Prometheus label used for scrapping                    | `prometheus`
+Key |                               Description                               | Default
+--: |:-----------------------------------------------------------------------:| :--
+`image.repository` |                            ocsinventory Image                           | `ocsinventory/ocsinventory-docker-image`
+`image.pullPolicy` |                            Image pull policy                            | `IfNotPresent`
+`image.tag` |                              Image version                              | `2.12.1`
+`replicaCount` |                      Number of ocs pod to deployed                      | `1`
+`phpconfig.ocsinventory.ini` |                     Additional php.ini configuration                    | `config`
+`persistense.enabled` |                       Enable persistence using PVC                      | `true`
+`persistense.size` |                    PVC Storage Request for OCS volume                   | `10Gi`
+`persistense.accessMode` |                      PVC Access Mode for OCS volume                     | `ReadWriteOnce`
+`persistense.storageClass` |                     PVC Storage Class for OCS volume                    | `""`
+`persistense.existingClaim` |                   An Existing PVC name for OCS volume                   | `""`
+`externalDatabase.enalbed` |                     Whether to use external database                    | `false`
+`externalDatabase.hostname` |                      Host of the external database                      | `""`
+`externalDatabase.username` |                    Username of the external database                    | `""`
+`externalDatabase.password` |              Password for the user of the external database             | `""`
+`externalDatabase.database` |                       Name of the external databse                      | `""`
+`database.create` |                     Wether to create a OCS database                     | `false`
+`database.db_name` |                         Database name to create                         | `""`
+`database.db_user` |                         Database user to create                         | `""`
+`database.db_pass` |                        Password for the database                        | `""`
+`database.db_server` |                       Name of the database service                      | `""`
+`mariadb.enabled` |                    Whether to create a MariaDB server                   | `true`
+`mariadb.auth.rootPasswd` |                          MariaDB admin password                         | `""`
+`mariadb.auth.database` |                         Database name to create                         | `""`
+`mariadb.auth.username` |                         Database user to create                         | `""`
+`mariadb.auth.password` |                          Password for the user                          | `""`
+`ingress.enabled` |                    Enable use of ingress controllers                    | `true`
+`ingress.tls` |                        Use dedicated certificates                       | `true`
+`ingress.ingressClassName` |                    Ingress Class Name for k8s >= v1.18                  | `""`
+`ingress.hosts` |                   OCS hosts to create application URLs                  | `""`
+`ingress.annotations` |                     An array of ingress annotations                     | `{}`
+`ingress.basicauth.enabled`  |                       Wether to enable basic auth                       | `"false"`
+`ingress.basicauth.username`  |                         Username for basic auth                         | `""`
+`ingress.basicauth.password`  |                         Password for basic auth                         | `""`
+`ingress.basicauth.authRealm` |                           Basic auth directive                          | `Authentication Required`
+`ingress.basicauth.paths` |                          Paths with basic auth                          | `/ocsapi` `/ocsinventory`
+`resources` |             CPU/Memory resource requests/limits for OCS pod             | `{}`
+`metrics.enabled` |                              Enable metrics                             | `false`
+`metrics.image.repository` |                          apache-exporter Image                          | `docker.io/bitnami/apache-exporter`
+`metrics.image.tag` |                          Metrics image version                          | `1.0.3-debian-11-r2`
+`metrics.image.pullPolicy` |                        Metrics image pull policy                        | `IfNotPresent`
+`metrics.serviceMonitor.enabled` |                       Create ServiceMonitor object                      | `false`
+`metrics.serviceMonitor.label.prometheus` |                   Prometheus label used for scrapping                   | `prometheus`
 `metrics.serviceMonitor.label.release` |Release label used for scrapping (should be the prometheus instance name) | `tobedefined`
-`metrics.resources` |        CPU/Memory resource requests/limits for apache metrics pod        | `{}`
+`metrics.resources` |        CPU/Memory resource requests/limits for apache metrics pod       | `{}`
 
 
 

--- a/charts/ocsinventory/templates/ingress.yaml
+++ b/charts/ocsinventory/templates/ingress.yaml
@@ -10,6 +10,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- else }}
   tls:
     - hosts:
       {{- range .Values.ingress.hosts }}
@@ -49,6 +52,9 @@ metadata:
     nginx.ingress.kubernetes.io/auth-secret: {{ template "ocsinventory.fullname" . }}
     nginx.ingress.kubernetes.io/auth-realm: {{ .Values.ingress.basicauth.authRealm | quote }}
 spec:
+  {{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- else }}
   tls:
     - hosts:
       {{- range .Values.ingress.hosts }}

--- a/charts/ocsinventory/templates/ingress.yaml
+++ b/charts/ocsinventory/templates/ingress.yaml
@@ -6,11 +6,17 @@ metadata:
   labels:
     {{- include "ocsinventory.labels" . | nindent 4 }}
   annotations:
-  {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
+{{- with .Values.ingress.annotations }}
+{{- range $key, $value := . }}
+  {{- if and (eq $key "kubernetes.io/ingress.class") (semverCompare "<1.18.0" $.Capabilities.KubeVersion.Version) }}
+    {{ $key }}: {{ $value | quote }}
+  {{- else if ne $key "kubernetes.io/ingress.class" }}
+    {{ $key }}: {{ $value | quote }}
   {{- end }}
+{{- end }}
+{{- end }}
 spec:
-  {{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
+  {{- if and (semverCompare ">=1.18.0" .Capabilities.KubeVersion.Version) (hasKey .Values.ingress "ingressClassName") (not (empty .Values.ingress.ingressClassName)) }}
   ingressClassName: {{ .Values.ingress.ingressClassName }}
   {{- end }}
   tls:
@@ -45,14 +51,20 @@ metadata:
   labels:
     {{- include "ocsinventory.labels" . | nindent 4 }}
   annotations:
-  {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
+{{- with .Values.ingress.annotations }}
+{{- range $key, $value := . }}
+  {{- if and (eq $key "kubernetes.io/ingress.class") (semverCompare "<1.18.0" $.Capabilities.KubeVersion.Version) }}
+    {{ $key }}: {{ $value | quote }}
+  {{- else if ne $key "kubernetes.io/ingress.class" }}
+    {{ $key }}: {{ $value | quote }}
   {{- end }}
+{{- end }}
+{{- end }}
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: {{ template "ocsinventory.fullname" . }}
     nginx.ingress.kubernetes.io/auth-realm: {{ .Values.ingress.basicauth.authRealm | quote }}
 spec:
-  {{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
+  {{- if and (semverCompare ">=1.18.0" .Capabilities.KubeVersion.Version) (hasKey .Values.ingress "ingressClassName") (not (empty .Values.ingress.ingressClassName)) }}
   ingressClassName: {{ .Values.ingress.ingressClassName }}
   {{- end }}
   tls:

--- a/charts/ocsinventory/templates/ingress.yaml
+++ b/charts/ocsinventory/templates/ingress.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   {{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
   ingressClassName: {{ .Values.ingress.ingressClassName }}
-  {{- else }}
+  {{- end }}
   tls:
     - hosts:
       {{- range .Values.ingress.hosts }}
@@ -54,7 +54,7 @@ metadata:
 spec:
   {{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
   ingressClassName: {{ .Values.ingress.ingressClassName }}
-  {{- else }}
+  {{- end }}
   tls:
     - hosts:
       {{- range .Values.ingress.hosts }}

--- a/charts/ocsinventory/values.yaml
+++ b/charts/ocsinventory/values.yaml
@@ -78,13 +78,13 @@ mariadb:
 #
 ingress:
   enabled: true
-  ingressClassName: "nginx"
+  # ingressClassName: "nginx" # only for K8S >= v1.18
   labels: {}
   hosts:
     - ""
   tls: true
   annotations:
-    kubernetes.io/ingress.class: nginx
+    # kubernetes.io/ingress.class: nginx # only for K8S < v1.18
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: 200M
     nginx.ingress.kubernetes.io/proxy-connect-timeout: 300s

--- a/charts/ocsinventory/values.yaml
+++ b/charts/ocsinventory/values.yaml
@@ -78,6 +78,7 @@ mariadb:
 #
 ingress:
   enabled: true
+  ingressClassName: "nginx"
   labels: {}
   hosts:
     - ""


### PR DESCRIPTION
We need for k8s clusters v1.18+ the ingressClassName in the ingress.

This PR adds the ability to add either the ingressClassName or the ingress class annotation, with a version check to avoid errors.

Tested on k8s  v1.25.6
(tests on version v1.18 or less are welcome)
