### PR TITLE
added check for persistence: enabled

### DIFF
--- a/charts/ocsinventory/templates/deployment.yaml
+++ b/charts/ocsinventory/templates/deployment.yaml
@@ -58,6 +58,7 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
+            {{- if .Values.persistence.enabled }}
             - mountPath: /etc/ocsinventory-server
               name: {{ template "ocsinventory.fullname" . }}-data
               subPath: perlcomdata
@@ -70,6 +71,7 @@ spec:
             - mountPath: /etc/apache2/conf-available
               name: {{ template "ocsinventory.fullname" . }}-data
               subPath: httpdconfdata
+            {{- end }}
             - mountPath: /etc/php/8.1/apache2/conf.d/ocsinventory.ini
               name: {{ template "ocsinventory.fullname" . }}-config
               subPath: phpconfig
@@ -86,6 +88,7 @@ spec:
 
         {{- end }}
       volumes:
+        {{- if .Values.persistence.enabled }}
         - name: {{ template "ocsinventory.fullname" . }}-data
           persistentVolumeClaim:
             {{- if .Values.persistence.existingClaim }}
@@ -93,6 +96,7 @@ spec:
             {{- else }}
             claimName: {{ template "ocsinventory.fullname" . }}-data
             {{- end }}
+        {{- end }}
         - name: {{ template "ocsinventory.fullname" . }}-config
           configMap:
             name: {{ template "ocsinventory.fullname" . }}-config


### PR DESCRIPTION
Hello everybody.
I had an issue using this helm chart. When I tried to install ocs without the pvc, it  would show an error saying that the volume ocsinventory-data couldn't be found. So I decided to check for the enable before using the volumes and volumeMounts config in the deployment template.
I hope you find this contribution useful!