### PR TITLE
🔒 Enable securityContext Configuration in OCS Inventory Helm Chart

### DIFF
--- a/charts/ocsinventory/templates/deployment.yaml
+++ b/charts/ocsinventory/templates/deployment.yaml
@@ -22,10 +22,14 @@ spec:
         {{ toYaml .Values.podAnnotations | indent 8 }}
       {{- end }}
     spec:
+      securityContext:
+      {{- toYaml .Values.podSecurityContext | nindent 8}}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+          {{- toYaml .Values.securityContext | nindent 10}}
           ports:
             - name: http
               containerPort: 80
@@ -77,6 +81,8 @@ spec:
         - name: {{ .Chart.Name }}-apache-metrics
           image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
+          securityContext:
+          {{- toYaml .Values.securityContext | nindent 10}}
           ports:
             - name: metrics
               containerPort: 9117

--- a/charts/ocsinventory/values.yaml
+++ b/charts/ocsinventory/values.yaml
@@ -18,6 +18,8 @@ fullnameOverride: ""
 podAnnotations: {}
 deploymentAnnotations: {}
 Labels: {}
+podSecurityContext: {}
+securityContext: {}
 
 ## PHP configuration
 ## https://www.php.net/manual/ini.core.php


### PR DESCRIPTION
Currently, the pods deployed via the OCS Inventory Helm chart do not enforce security best practices such as running as a non-root user. To improve security and compliance, we should allow setting a securityContext in the Helm chart values and apply it to each pod by default.

https://github.com/OCSInventory-NG/helm-charts/issues/14